### PR TITLE
fixed capture button border display in firefox and safari, now button…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -116,6 +116,7 @@ iframe{
   overflow:hidden;
   background-image:url('../img/cameraCapture.png');
   background-size: cover;
+  border: none;
 
 }
 


### PR DESCRIPTION
… will show no borders